### PR TITLE
GH-8 Wordlist panic fix

### DIFF
--- a/internal/scan/options.go
+++ b/internal/scan/options.go
@@ -280,6 +280,14 @@ func LoadTextWordlist(fns []string, extensions []string, dirsearchCompatabilityM
 				return nil
 			}
 
+			if strings.HasSuffix(filename, ".kite") {
+				return fmt.Errorf("attempted to load kitefile as plain text wordlist: %s. Please provide a plain wordlist", filename)
+			}
+
+			if strings.HasSuffix(filename, ".json") {
+				return fmt.Errorf("attempted to load json as plain text wordlist: %s. Please provide a plain wordlist", filename)
+			}
+
 			lines, err := readLines(filename)
 			if err != nil {
 				return fmt.Errorf("failed to load file %s: %w", filename, err)

--- a/internal/scan/options.go
+++ b/internal/scan/options.go
@@ -286,6 +286,9 @@ func LoadTextWordlist(fns []string, extensions []string, dirsearchCompatabilityM
 			}
 
 			for _, v := range lines {
+				if len(v) == 0 {
+					continue
+				}
 				// ensure we prepend the / for a path
 				if v[0] != '/' {
 					v = append([]byte("/"), v...)


### PR DESCRIPTION
Fixes https://github.com/assetnote/kiterunner/issues/8

* handles empty lines in wordlist
* handles `.kite` and `.json` filetypes in normal wordlist loading. 