### PR TITLE
fix(cli-scan): avoid double appending / in the basepath and route path in output

### DIFF
--- a/internal/scan/parse_test.go
+++ b/internal/scan/parse_test.go
@@ -69,8 +69,11 @@ func TestParseDomain(t *testing.T) {
 	}{
 		{"simple", args{"foo.com"}, []*http.Target{{IsTLS: true, Hostname: "foo.com", Port: 443}, {Hostname: "foo.com", Port: 80}}, false},
 		{"full uri", args{"https://foo.com"}, []*http.Target{{IsTLS: true, Hostname: "foo.com", Port: 443}}, false},
+		{"full uri trailing slash", args{"https://foo.com/"}, []*http.Target{{IsTLS: true, Hostname: "foo.com", Port: 443, BasePath: "/"}}, false},
+		{"full uri trailing slash subdir", args{"https://foo.com/bar/"}, []*http.Target{{IsTLS: true, Hostname: "foo.com", Port: 443, BasePath: "/bar/"}}, false},
 		{"full uri with port", args{"https://foo.com:8443"}, []*http.Target{{IsTLS: true, Hostname: "foo.com", Port: 8443}}, false},
 		{"full http with port", args{"http://foo.com:8080"}, []*http.Target{{IsTLS: false, Hostname: "foo.com", Port: 8080}}, false},
+		{"full http with port trailing slash", args{"http://foo.com:8080/"}, []*http.Target{{IsTLS: false, Hostname: "foo.com", Port: 8080, BasePath: "/"}}, false},
 		{"full http with port and path", args{"http://foo.com:8080/path"}, []*http.Target{{IsTLS: false, Hostname: "foo.com", Port: 8080, BasePath: "/path"}}, false},
 		{"host with port tls", args{"foo.com:8443"}, []*http.Target{{IsTLS: true, Hostname: "foo.com", Port: 8443}}, false},
 		{"host with port notls", args{"foo.com:8080"}, []*http.Target{{IsTLS: false, Hostname: "foo.com", Port: 8080}}, false},

--- a/pkg/kiterunner/result.go
+++ b/pkg/kiterunner/result.go
@@ -164,7 +164,16 @@ func (r *Result) AppendPrettyBytes(b []byte) []byte {
 
 	// Append the path
 	b = r.Target.AppendBytes(b)
-	b = r.Route.AppendPath(b)
+
+	// avoid double appending a path where its not necessary
+	// this destroys branch prediction. which is annoying, but not sure where else we can handle this
+	// its a pretty unlikely case since its only hit when printing results
+	if b[len(b)-1] == '/' && len(r.Route.Path) > 0 && r.Route.Path[0] == '/' {
+		b = append(b, r.Route.Path[1:]...)
+	} else {
+		b = r.Route.AppendPath(b)
+	}
+
 	b = append(b, " "...)
 
 	b = appendColorEnd(b)
@@ -198,7 +207,15 @@ func (r *Result) AppendBytes(b []byte) []byte {
 
 	// Append the path
 	b = r.Target.AppendBytes(b)
-	b = r.Route.AppendPath(b)
+
+	// avoid double appending a path where its not necessary
+	// this destroys branch prediction. which is annoying, but not sure where else we can handle this
+	// its a pretty unlikely case since its only hit when printing results
+	if b[len(b)-1] == '/' && len(r.Route.Path) > 0 && r.Route.Path[0] == '/' {
+		b = append(b, r.Route.Path[1:]...)
+	} else {
+		b = r.Route.AppendPath(b)
+	}
 	b = append(b, " "...)
 
 	b = r.Response.AppendRedirectChain(b)


### PR DESCRIPTION
Fixes #13 .

This changes the PrintOutput function for displaying results in pretty and text mode.

this will inspect the output bytes for the target to avoid printing both
a trailing / on the basepath and a prefix / for the route path.
This is purely a cosmetic change, as our underlying request engine
already collapses duplicate paths

so now the behaviour will occurs as follows:

```
http://foo.com/foo + /bar.txt => http://foo.com/foo/bar.txt (as normal)
http://foo.com/foo + bar.txt => http://foo.com/foo/bar.txt (our wordlist loading prefixes / for you)
http://foo.com/foo + /bar.txt => http://foo.com/foo/bar.txt
http://foo.com/foo/ + /bar.txt => http://foo.com/foo/bar.txt (the bar.txt slash is dropped)
http://foo.com/foo// + /bar.txt => http://foo.com/foo//bar.txt (the bar.txt slash is dropped, but you added two, so thats your fault)
```

We also add some tests to validate that the parsing of the basepath is as we expect with trailing slashes.

In the future, we may want to modify the behaviour of the routes loading to not prepend the '/' so if you specify `http://foo.com/bar` and `file.txt` you'll get `http://foo.com/barfile.txt` without a joining slash.
