### PR TITLE
docs: fix typo in wordlists url

### DIFF
--- a/cmd/kiterunner/cmd/brute.go
+++ b/cmd/kiterunner/cmd/brute.go
@@ -132,5 +132,5 @@ func init() {
 	bruteCmd.Flags().StringVar(&profileName, "profile-name", profileName, "name for profile output file")
 
 	bruteCmd.Flags().StringSliceVar(&filterAPIs, "filter-api", filterAPIs, "only scan apis matching this ksuid")
-	bruteCmd.Flags().StringSliceVarP(&assetnoteWordlist, "assetnote-wordlist", "A", assetnoteWordlist, "use the wordlists from wordlist.assetnote.io. specify the type/name to use, e.g. apiroutes-210228. You can specify an additional maxlength to use only the first N values in the wordlist, e.g. apiroutes-210228;20000 will only use the first 20000 lines in that wordlist")
+	bruteCmd.Flags().StringSliceVarP(&assetnoteWordlist, "assetnote-wordlist", "A", assetnoteWordlist, "use the wordlists from wordlists.assetnote.io. specify the type/name to use, e.g. apiroutes-210228. You can specify an additional maxlength to use only the first N values in the wordlist, e.g. apiroutes-210228;20000 will only use the first 20000 lines in that wordlist")
 }

--- a/cmd/kiterunner/cmd/scan.go
+++ b/cmd/kiterunner/cmd/scan.go
@@ -158,5 +158,5 @@ func init() {
 
 	scanCmd.Flags().StringSliceVar(&filterAPIs, "filter-api", filterAPIs, "only scan apis matching this ksuid")
 
-	scanCmd.Flags().StringSliceVarP(&assetnoteWordlist, "assetnote-wordlist", "A", assetnoteWordlist, "use the wordlists from wordlist.assetnote.io. specify the type/name to use, e.g. apiroutes-210228. You can specify an additional maxlength to use only the first N values in the wordlist, e.g. apiroutes-210228;20000 will only use the first 20000 lines in that wordlist")
+	scanCmd.Flags().StringSliceVarP(&assetnoteWordlist, "assetnote-wordlist", "A", assetnoteWordlist, "use the wordlists from wordlists.assetnote.io. specify the type/name to use, e.g. apiroutes-210228. You can specify an additional maxlength to use only the first N values in the wordlist, e.g. apiroutes-210228;20000 will only use the first 20000 lines in that wordlist")
 }

--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,7 @@ Usage:
   kite scan [flags]
 
 Flags:
-  -A, --assetnote-wordlist strings    use the wordlists from wordlist.assetnote.io. specify the type/name to use, e.g. apiroutes-210228. You can specify an additional maxlength to use only the first N values in the wordlist, e.g. apiroutes-210228;20000 will only use the first 20000 lines in that wordlist
+  -A, --assetnote-wordlist strings    use the wordlists from wordlists.assetnote.io. specify the type/name to use, e.g. apiroutes-210228. You can specify an additional maxlength to use only the first N values in the wordlist, e.g. apiroutes-210228;20000 will only use the first 20000 lines in that wordlist
       --blacklist-domain strings      domains that are blacklisted for redirects. We will not follow redirects to these domains
       --delay duration                delay to place inbetween requests to a single host
       --disable-precheck              whether to skip host discovery


### PR DESCRIPTION
Just a simple fix on the wordlists url :)