### PR TITLE
Fix for Delay function and Header definition

### DIFF
--- a/cmd/kiterunner/cmd/brute.go
+++ b/cmd/kiterunner/cmd/brute.go
@@ -104,7 +104,9 @@ func init() {
 	bruteCmd.Flags().StringSliceVarP(&extensions, "extensions", "e", extensions, "extensions to append while scanning")
 	bruteCmd.Flags().BoolVarP(&dirsearchCompatabilityMode, "dirsearch-compat", "D", dirsearchCompatabilityMode, "this will replace %EXT% with the extensions provided. backwards compat with dirsearch because shubs loves him some dirsearch")
 
-	bruteCmd.Flags().StringSliceVarP(&headers, "header", "H", []string{"x-forwarded-for: 127.0.0.1"}, "headers to add to requests")
+	// bruteCmd.Flags().StringSliceVarP(&headers, "header", "H", []string{"x-forwarded-for: 127.0.0.1"}, "headers to add to requests")
+	// Fix for improper header definition
+	bruteCmd.Flags().StringArrayVarP(&headers, "header", "H", []string{"x-forwarded-for: 127.0.0.1"}, "headers to add to requests")
 
 	bruteCmd.Flags().BoolVar(&disablePrecheck, "disable-precheck", false, "whether to skip host discovery")
 

--- a/cmd/kiterunner/cmd/scan.go
+++ b/cmd/kiterunner/cmd/scan.go
@@ -129,7 +129,9 @@ func init() {
 
 	scanCmd.Flags().StringSliceVarP(&kitebuilderFiles, "kitebuilder-list", "w", kitebuilderFiles, "ogl wordlist to use for scanning")
 	scanCmd.Flags().BoolVar(&kitebuilderFullScan, "kitebuilder-full-scan", kitebuilderFullScan, "perform a full scan without first performing a phase scan.")
-	scanCmd.Flags().StringSliceVarP(&headers, "header", "H", []string{"x-forwarded-for: 127.0.0.1"}, "headers to add to requests")
+	//scanCmd.Flags().StringSliceVarP(&headers, "header", "H", []string{"x-forwarded-for: 127.0.0.1"}, "headers to add to requests")
+	// Fix for improper header definition
+	scanCmd.Flags().StringArrayVarP(&headers, "header", "H", []string{"x-forwarded-for: 127.0.0.1"}, "headers to add to requests")
 
 	scanCmd.Flags().BoolVar(&disablePrecheck, "disable-precheck", false, "whether to skip host discovery")
 

--- a/pkg/kiterunner/kiterunner.go
+++ b/pkg/kiterunner/kiterunner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/assetnote/kiterunner/pkg/http"
 	"github.com/assetnote/kiterunner/pkg/log"

--- a/pkg/kiterunner/kiterunner.go
+++ b/pkg/kiterunner/kiterunner.go
@@ -256,6 +256,12 @@ func handleRequest(ctx context.Context, j *job, resChan chan *Result, config *Co
 
 routeloop:
 	for idx, route := range j.routes {
+		// Extra Line added to fix Delay function
+		if config.Delay > 0 {
+			time.Sleep(config.Delay)
+		}
+		// Extra Line added to fix Delay function
+		
 		// periodically check if the channel has terminated so we can exit
 		// TODO: not sure how this affects branch prediction on the loop, or whether there's a noticable performance impact
 		// i presume not, since 99% of the time we're waiting on network

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,13 @@
+# FIXES [README]
+What's different in this version?
+During my assessments, I've identified some concerning flaws with Kiterunner, which prevented me from bypassing some security solutions, like WAFs.
+
+The first problem was that I couldn't correctly define header values in the request. There were some WAF header values that, when introduced into Kiterunner's -H flag, it would interpret the comma (,) as multiple header values and not as a single header value. This would make it impossible to define headers with comma values. I've identified that this happens because Kiterunner utilizes StringSliceVarP instead of StringArrayVarP to get header values. StringSliceVarP would interpret the comma value as CSV, separating it into multiple headers.
+
+The second problem was with the delay function (--delay). I've identified that it doesn't matter which kind of value you input into Kiterunner; it will not have any effect. It's like it's not used at all. Well, that's actually what's happening here. Even though the delay value is retrieved from the input, it's not used when making the HTTP requests. If you look at pkg/kiterunner/kiterunner.go in the handleRequest function, specifically in routeloop, you will see that the Config.delay isn't used. To fix this, I've introduced a line of code that makes the program sleep for a while (depending on the --delay value).
+
+That's it. Now you can properly define a delay and security headers without any problems :)
+
 # Kiterunner
 
 ![](/hack/kiterunner.png)


### PR DESCRIPTION
During my assessments, I've identified some concerning flaws with Kiterunner, which prevented me from bypassing some security solutions, like WAFs.

The first problem was that I couldn't correctly define header values in the request. There were some WAF header values that, when introduced into Kiterunner's -H flag, it would interpret the comma (,) as multiple header values and not as a single header value. This would make it impossible to define headers with comma values. I've identified that this happens because Kiterunner utilizes StringSliceVarP instead of StringArrayVarP to get header values. StringSliceVarP would interpret the comma value as CSV, separating it into multiple headers.

The second problem was with the delay function (--delay). I've identified that it doesn't matter which kind of value you input into Kiterunner; it will not have any effect. It's like it's not used at all. Well, that's actually what's happening here. Even though the delay value is retrieved from the input, it's not used when making the HTTP requests. If you look at pkg/kiterunner/kiterunner.go in the handleRequest function, specifically in routeloop, you will see that the Config.delay isn't used. To fix this, I've introduced a line of code that makes the program sleep for a while (depending on the --delay value).

That's it. Now its possible to properly define a delay and security headers.